### PR TITLE
feat(treesitter): pass position_id as string

### DIFF
--- a/lua/neotest-phpunit/init.lua
+++ b/lua/neotest-phpunit/init.lua
@@ -46,7 +46,7 @@ function NeotestAdapter.discover_positions(path)
   ]]
 
   return lib.treesitter.parse_positions(path, query, {
-    position_id = utils.make_test_id,
+    position_id = "require('neotest-phpunit.utils').make_test_id",
   })
 end
 


### PR DESCRIPTION
Enables subprocess parsing.
See https://github.com/nvim-neotest/neotest/issues/13#issuecomment-1260570396