### PR TITLE
Remove "Feature" test suite from phpunit.xml

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,9 +8,6 @@
         <testsuite name="Unit">
             <directory suffix="Test.php">./tests/Unit</directory>
         </testsuite>
-        <testsuite name="Feature">
-            <directory suffix="Test.php">./tests/Feature</directory>
-        </testsuite>
         <testsuite name="Examples">
             <directory suffix="Test.php">./tests/Examples</directory>
         </testsuite>


### PR DESCRIPTION
Causes error because the Feature folder does not exist
```
➤_ phpunit
PHPUnit 9.6.6 by Sebastian Bergmann and contributors.

Test directory "/e/git/heimer16/neotest-phpunit/./tests/Feature" not found
```