### PR TITLE
Add option to _ignore_ a project root based on file existence

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,16 @@ require("neotest-phpunit")({
 })
 ```
 
+If there are projects you don't want discovered, you can instead set `root_ignore_files` to ignore any matching projects. 
+
+For example, if your project uses Pest and the appropriate [neotest adapter](https://github.com/V13Axel/neotest-pest), you'll need to set:
+
+```lua
+require("neotest-phpunit")({
+    root_ignore_files = { "tests/Pest.php" }
+})
+```
+
 ### Filtering directories
 
 By default, the adapter will search test files in all dirs in the root with the exception of `node_modules` and `.git`. You can change this with:

--- a/lua/neotest-phpunit/config.lua
+++ b/lua/neotest-phpunit/config.lua
@@ -8,6 +8,10 @@ M.get_env = function()
   return {}
 end
 
+M.get_root_ignore_files = function()
+  return {}
+end
+
 M.get_root_files = function()
   return { "composer.json", "phpunit.xml", ".gitignore" }
 end

--- a/lua/neotest-phpunit/init.lua
+++ b/lua/neotest-phpunit/init.lua
@@ -59,6 +59,11 @@ local NeotestAdapter = { name = "neotest-phpunit" }
 function NeotestAdapter.root(dir)
   local result = nil
 
+  for _, root_ignore_file in ipairs(config.get_root_ignore_files()) do
+    result = lib.files.match_root_pattern(root_ignore_file)(dir)
+    if result then return nil end
+  end
+
   for _, root_file in ipairs(config.get_root_files()) do
     result = lib.files.match_root_pattern(root_file)(dir)
     if result then break end
@@ -196,6 +201,13 @@ setmetatable(NeotestAdapter, {
     elseif opts.phpunit_cmd then
       config.get_phpunit_cmd = function()
         return opts.phpunit_cmd
+      end
+    end
+    if is_callable(opts.root_ignore_files) then
+      config.get_root_ignore_files = opts.root_ignore_files
+    elseif opts.root_ignore_files then
+      config.get_root_ignore_files = function()
+        return opts.root_ignore_files
       end
     end
     if is_callable(opts.root_files) then


### PR DESCRIPTION
This PR adds a new config option, `root_ignore_files`, a table of files whose presence mean a project should _not_ be considered a phpunit project. My main goal here is to prevent `neotest-phpunit` from claiming projects setup for [Pest](https://pestphp.com/).

You may already be familiar, but just in case: Pest uses PHPUnit under the hood. As such, `phpunit.xml` exists. However, its tests are not _compatible_ with PHPUnit's - so running `phpunit` directly in a Pest project will just crash.

Essentially, [I've forked `neotest-pest`](https://github.com/V13Axel/neotest-pest), updated it for the latest version of pest, and started using it. It's just that sometimes when I hit my `run()` key, `neotest-phpunit` seems to "speak up" first and decides my tests are failing (due to the aforementioned crash). I wind up needing to manually select `neotest-pest` in the summary window or some other janky workaround. :sweat_smile: 

However, since Pest's setup adds a file `tests/Pest.php`, that's where this new `root_ignore_files` option comes in. It can be set to `root_ignore_files = { "tests/Pest.php" }` and `neotest-phpunit` simply ignores the project.