### PR TITLE
Discovering tests marked with attribute

### DIFF
--- a/lua/neotest-phpunit/init.lua
+++ b/lua/neotest-phpunit/init.lua
@@ -110,6 +110,16 @@ function NeotestAdapter.discover_positions(path)
         (name) @test.name
       ) @test.definition
     ))
+
+	(((method_declaration
+	  (attribute_list
+	    (attribute_group
+		  (attribute) @test_attribute (#match? @test_attribute "^Test$")
+		)
+	  )
+	  (name) @test.name
+	  )
+	)) @test.definition
   ]]
 
   return lib.treesitter.parse_positions(path, query, {

--- a/lua/neotest-phpunit/init.lua
+++ b/lua/neotest-phpunit/init.lua
@@ -102,7 +102,7 @@ function NeotestAdapter.discover_positions(path)
     )) @namespace.definition
 
     ((method_declaration
-      (name) @test.name (#match? @test.name "test")
+      (name) @test.name (#match? @test.name "^test")
     )) @test.definition
 
     (((comment) @test_comment (#match? @test_comment "\\@test") .

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class ExampleTest extends TestCase
 {
@@ -36,6 +37,17 @@ class ExampleTest extends TestCase
     {
         $this->assertTrue(true);
     }
+
+	public function this_test_should_not_run_also()
+	{
+		$this->assertTrue(true);
+	}
+
+	#[Test]
+	public function this_test_should_run()
+	{
+		$this->assertTrue(true);
+	}
 
     /**
      * @dataProvider myProvider


### PR DESCRIPTION
Hello!
Just started working with this package and find that it does not find tests marked with attribute. I think this is important since marking with phpdoc is deprecatred by phpunit.

Here is my PR to support attribute marking.

It also contains commit, that fixes test dicovering by method name.
Phpunit documentation says that method name should start with 'test', but regex in query hits even if 'test' is in middle of method name.

Thank you!