### PR TITLE
Ignoring non test files to avoid TS processing

### DIFF
--- a/lua/neotest-phpunit/init.lua
+++ b/lua/neotest-phpunit/init.lua
@@ -96,6 +96,10 @@ end
 ---@param file_path string Absolute file path
 ---@return neotest.Tree | nil
 function NeotestAdapter.discover_positions(path)
+  if not NeotestAdapter.is_test_file(path) then
+    return nil
+  end
+
   local query = [[
     ((class_declaration
       name: (name) @namespace.name (#match? @namespace.name "Test")


### PR DESCRIPTION
I don't know why, but neotest runs this method every time I open a file.

I'm using lazy to lazy-load neotest, but after it gets loaded, I see a very noticeable slowness whenever I open a file that wasn't in a buffer.

I'm pretty sure this is a neotest issue, but I couldn't figure it out where the problem is in their codebase, that's why I'm opening this PR here. Maybe it will help someone else too.