### PR TITLE
Support older phpunit version

### DIFF
--- a/lua/neotest-phpunit/utils.lua
+++ b/lua/neotest-phpunit/utils.lua
@@ -60,9 +60,10 @@ local function make_outputs(test, output_file)
   local test_id = test_attr.file .. separator .. test_attr.line
   logger.info("PHPUnit id:", { test_id })
 
+  local classname = test_attr.classname or test_attr.class
   local test_output = {
     status = "passed",
-    short = string.upper(test_attr.classname) .. "\n-> " .. "PASSED" .. " - " .. test_attr.name,
+    short = string.upper(classname) .. "\n-> " .. "PASSED" .. " - " .. test_attr.name,
     output_file = output_file,
   }
 


### PR DESCRIPTION
Tested with phpunit 5.7.27

Example XML from this phpunit version:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites>
  <testsuite name="SomeClassTest" file="/path/to/SomeClassTest.php" tests="1" assertions="5" failures="0" errors="0" time="0.039746">
    <testcase name="test_some_case" class="HttpClientTest" file="/path/to/SomeClassTest.php" line="20" assertions="5" time="0.039746"/>
  </testsuite>
</testsuites>
```