### PR TITLE
Do not overwrite existing failure results for existing test_id

### DIFF
--- a/lua/neotest-phpunit/utils.lua
+++ b/lua/neotest-phpunit/utils.lua
@@ -90,7 +90,11 @@ local function iterate_test_outputs(tests, output_file, output_table)
   for i = 1, #tests, 1 do
     if #tests[i] == 0 then
       local test_id, test_output = make_outputs(tests[i], output_file)
-      output_table[test_id] = test_output
+      if output_table[test_id] ~= nil and output_table[test_id].status == "failed" then
+        -- keep previously failed result
+      else
+        output_table[test_id] = test_output
+      end
     else
       iterate_test_outputs(tests[i], output_file, output_table)
     end

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -52,4 +52,41 @@ class ExampleTest extends TestCase
             'set two' => [false],
         ];
     }
+
+    /**
+     * @dataProvider myProviderEndingWithAllTrue
+     */
+    public function testWithDataProviderShouldPassIfAllTrue(bool $val): void
+    {
+        $this->assertTrue($val);
+    }
+
+    public static function myProviderEndingWithAllTrue(): array
+    {
+        return [
+            [true],
+            [true],
+            [true],
+            [true],
+        ];
+    }
+
+    /**
+     * @dataProvider myProviderWithFailure
+     */
+    public function testWithDataProviderShouldFailIfAnyFailure(bool $val): void
+    {
+        $this->assertTrue($val);
+    }
+
+    public static function myProviderWithFailure(): array
+    {
+        return [
+            [true],
+            [false],
+            [true],
+            [true],
+        ];
+    }
 }
+


### PR DESCRIPTION
Probably not the best fix but enough of a band-aid to fix the inaccurate status.  

I did play around with creating a unique id for each dataset result, but couldn't get it to work.  
i.e. splitting on the "with data set" string in the name and appending that to the id

With this fix, it just means that instead of always returning the last result in the dataset, it will return the first failed result, otherwise the last result.