### PR TITLE
Making it compatible with Lazy.nvim

### DIFF
--- a/lua/neotest-phpunit/init.lua
+++ b/lua/neotest-phpunit/init.lua
@@ -137,7 +137,7 @@ function NeotestAdapter.discover_positions(path)
   ]]
 
   return lib.treesitter.parse_positions(path, query, {
-    position_id = "require('neotest-phpunit.utils').make_test_id",
+    position_id = utils.make_test_id,
   })
 end
 


### PR DESCRIPTION
Pass `utils.make_test_id`  as a function instead of a string to make it compatible with async nature of neotest to parse positions.

The problem:
Neotest initiates a headless embed nvim instance with no user configuration and adds only its core dependencies. 
Because of that when the treesitter parser executed on the instance, the `neotest-phpunit.utils` package was not exists. 
 