### PR TITLE
Run tests in docker and generate coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ adapters = {
     filter_dirs = { ".git", "node_modules" },
     env = {}, -- for example {XDEBUG_CONFIG = 'idekey=neotest'}
     dap = nil, -- to configure `dap` strategy put single element from `dap.configurations.php`
+    docker = {
+      enabled = false,
+      container_name = "php",
+      container_port = "9000",
+      container_workdir = nil,
+    },
   }),
 }
 ```

--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ adapters = {
       container_port = "9000",
       container_workdir = nil,
     },
+    coverage = {
+      enabled = false,
+      args = "--coverage-cobertura",
+      path = "coverage/cobertura.xml",
+    },
   }),
 }
 ```

--- a/lua/neotest-phpunit/config.lua
+++ b/lua/neotest-phpunit/config.lua
@@ -34,4 +34,16 @@ M.get_docker_options = function()
   }
 end
 
+---@class config.coverage
+---@field enabled boolean
+---@field args string
+---@field path string
+M.get_coverage_options = function()
+  return {
+    enabled = false,
+    args = "--coverage-cobertura",
+    path = "coverage/cobertura.xml",
+  }
+end
+
 return M

--- a/lua/neotest-phpunit/config.lua
+++ b/lua/neotest-phpunit/config.lua
@@ -20,4 +20,18 @@ M.get_filter_dirs = function()
   return { ".git", "node_modules" }
 end
 
+---@class config.docker
+---@field enabled boolean
+---@field container_name string
+---@field container_port string
+---@field container_workdir string?
+M.get_docker_options = function()
+  return {
+    enabled = false,
+    container_name = "php",
+    container_port = "9000",
+    container_workdir = nil,
+  }
+end
+
 return M

--- a/lua/neotest-phpunit/docker.lua
+++ b/lua/neotest-phpunit/docker.lua
@@ -233,7 +233,8 @@ end
 
 ---Copy test results to host machine
 ---@param output_path string
-function Docker.copy_to_host(output_path)
+---@param coverage_config config.coverage
+function Docker.copy_to_host(output_path, coverage_config)
   vim.system({ Docker.cmd, "cp", "-a", Docker.get_container_id() .. ":" .. output_path, output_path }):wait()
   vim
     .system({
@@ -244,6 +245,16 @@ function Docker.copy_to_host(output_path)
       output_path,
     })
     :wait()
+
+  if coverage_config.enabled then
+    vim.system({
+      Docker.cmd,
+      "cp",
+      "-a",
+      Docker.get_container_id() .. ":" .. coverage_config.path,
+      Docker.root_path .. "/" .. coverage_config.path,
+    })
+  end
 end
 
 return Docker

--- a/lua/neotest-phpunit/docker.lua
+++ b/lua/neotest-phpunit/docker.lua
@@ -1,0 +1,249 @@
+-- TODO: Invalidate cache when daemon or php container is stopped
+
+local logger = require("neotest.logging")
+local lib = require("neotest.lib")
+
+---@class Docker
+local Docker = {}
+
+---@private
+Docker.cmd = "docker"
+
+---@private
+Docker.files = {
+  "Dockerfile",
+  "docker-compose.yaml",
+  "docker-compose.yml",
+  "compose.yaml",
+  "compose.yml",
+}
+
+---@private
+Docker.cache = {}
+
+---Checks if docker daemon is running
+function Docker.is_daemon_running()
+  if Docker.cache.is_daemon_running then
+    return Docker.cache.is_daemon_running
+  end
+
+  local is_daemon_running = vim.system({ Docker.cmd, "version", "--format", "{{.Server.Version}}" }):wait()
+
+  Docker.cache.is_daemon_running = is_daemon_running.code == 0
+
+  return Docker.cache.is_daemon_running
+end
+
+---Tries to resolve root path
+---@private
+Docker.get_root_path = function()
+  if Docker.cache.root then
+    return Docker.cache.root
+  end
+
+  for _, dockerfile in ipairs(Docker.files) do
+    local path = lib.files.match_root_pattern(dockerfile)(vim.fn.getcwd())
+    if path then
+      Docker.cache.root = path
+
+      return Docker.cache.root
+    end
+  end
+end
+
+---@private
+Docker.root_path = Docker.get_root_path()
+
+---Find container's id
+---@param filter? "name"|"publish"
+---@param value? string
+---@return string?
+function Docker.get_container_id(filter, value)
+  if Docker.cache.container_id then
+    logger.debug("Docker container id is cached. [" .. Docker.cache.container_id .. "]")
+    return Docker.cache.container_id
+  end
+
+  if filter and value then
+    local container_id =
+      vim.trim(vim.system({ Docker.cmd, "ps", "-q", "--filter", filter .. "=" .. value }):wait().stdout)
+
+    if container_id == "" then
+      logger.info("No running container with " .. filter .. ": " .. value)
+
+      return
+    end
+
+    Docker.cache.container_id = container_id
+
+    return Docker.cache.container_id
+  end
+end
+
+---Returns container's workdir
+---@return string
+function Docker.get_container_workdir()
+  if Docker.cache.container_workdir then
+    logger.debug(
+      "Docker container workdir for container with id "
+        .. Docker.cache.container_id
+        .. " is cached. ["
+        .. Docker.cache.container_workdir
+        .. "]"
+    )
+    return Docker.cache.container_workdir
+  end
+
+  local container_workdir = vim.trim(
+    vim.system({ Docker.cmd, "inspect", "--format", "{{.Config.WorkingDir}}", Docker.cache.container_id }):wait().stdout
+  )
+
+  if container_workdir == "" then
+    logger.info("No workdir for container with id: " .. Docker.cache.container_id)
+  end
+
+  Docker.cache.container_workdir = container_workdir
+
+  return Docker.cache.container_workdir
+end
+
+---Returns container's shell path
+---@return string
+function Docker.get_container_shell()
+  if Docker.cache.container_shell then
+    logger.debug(
+      "Docker container shell for container with id "
+        .. Docker.cache.container_id
+        .. " is cached. ["
+        .. Docker.cache.container_shell
+        .. "]"
+    )
+    return Docker.cache.container_shell
+  end
+
+  local container_shell = vim.trim(vim
+    .system({
+      Docker.cmd,
+      "exec",
+      "-i",
+      Docker.cache.container_id,
+      "/bin/sh",
+      "-c",
+      "if [ -f /bin/sh ]; then echo /bin/sh; else echo /bin/bash; fi | tr -d '\r'",
+    })
+    :wait().stdout)
+
+  if container_shell == "" then
+    logger.info("Shell path not found for container with id: " .. Docker.cache.container_id)
+  end
+
+  Docker.cache.container_shell = container_shell
+
+  return Docker.cache.container_shell
+end
+
+---Transform path to use workdir as cwd
+---@param host_path string
+---@return string
+function Docker.translate_path_to_container(host_path)
+  if vim.startswith(host_path, Docker.root_path) then
+    local relative_path = host_path:sub(#Docker.root_path + 2)
+    return Docker.get_container_workdir() .. "/" .. relative_path
+  end
+
+  return host_path
+end
+
+---Builds the script arguments for running PHPUnit inside a docker container
+---@param args {env: table<string, string>, phpunit_cmd: string, script_args: string[]}
+---@return string
+function Docker.build_script_args(args)
+  -- INFO: Prepend all env variables
+  local result = vim
+    .iter(args.env)
+    :map(function(k, v)
+      return k .. "=" .. v
+    end)
+    :totable()
+
+  table.insert(result, args.phpunit_cmd)
+  table.insert(result, Docker.translate_path_to_container(table.concat(args.script_args, " ")))
+
+  return table.concat(result, " ")
+end
+
+---Builds a DAP configuration for debugging PHPUnit tests inside a Docker container
+---@param dap_strategy table
+---@param args {phpunit_cmd: string, script_args: string[]}
+---@return table
+function Docker.dap_config(dap_strategy, args)
+  local dap_config = vim.deepcopy(dap_strategy)
+
+  dap_config.program = args.phpunit_cmd
+  dap_config.args = vim.split(Docker.translate_path_to_container(table.concat(args.script_args, " ")), " ")
+  dap_config.runtimeExecutable = Docker.cmd
+  dap_config.runtimeArgs = {
+    "exec",
+    "-w",
+    Docker.get_container_workdir(),
+    Docker.get_container_id(),
+    "php",
+    "-dxdebug.mode=debug",
+    "-dxdebug.discover_client_host=1",
+    "-dxdebug.client_host=host.docker.internal",
+    "-dxdebug.client_port=9003",
+    "-dxdebug.start_with_request=yes",
+    "-dxdebug.idekey=neovim",
+  }
+
+  return dap_config
+end
+
+---Setup phpunit command to execute tests in docker
+---@param args {env: table<string, string>, phpunit_cmd: string, script_args: string[]}
+---@param docker_config config.docker
+---@return string[]|nil
+function Docker.build_cmd(args, docker_config)
+  if not Docker.is_daemon_running() then
+    return
+  end
+
+  local container_id = Docker.get_container_id("name", docker_config.container_name)
+    or Docker.get_container_id("publish", docker_config.container_port)
+
+  if not container_id then
+    logger.error("Couldn't find container's id")
+    return
+  end
+
+  local container_workdir = Docker.get_container_workdir()
+  local container_shell = Docker.get_container_shell()
+
+  local script = Docker.build_script_args({
+    env = args.env,
+    phpunit_cmd = args.phpunit_cmd,
+    script_args = args.script_args,
+  })
+
+  local docker_cmd =
+    { Docker.cmd, "exec", "-i", { "-w", container_workdir }, container_id, container_shell, "-c", script }
+
+  return vim.iter(docker_cmd):flatten():totable()
+end
+
+---Copy test results to host machine
+---@param output_path string
+function Docker.copy_to_host(output_path)
+  vim.system({ Docker.cmd, "cp", "-a", Docker.get_container_id() .. ":" .. output_path, output_path }):wait()
+  vim
+    .system({
+      "sed",
+      "-i",
+      "_",
+      "s#" .. Docker.get_container_workdir() .. "#" .. Docker.root_path .. "#g",
+      output_path,
+    })
+    :wait()
+end
+
+return Docker

--- a/lua/neotest-phpunit/init.lua
+++ b/lua/neotest-phpunit/init.lua
@@ -7,6 +7,7 @@ local lib = require("neotest.lib")
 local logger = require("neotest.logging")
 local utils = require("neotest-phpunit.utils")
 local config = require("neotest-phpunit.config")
+local docker = require("neotest-phpunit.docker")
 
 local dap_configuration
 
@@ -147,6 +148,7 @@ function NeotestAdapter.build_spec(args)
   local position = args.tree:data()
   local results_path = async.fn.tempname()
   local program = config.get_phpunit_cmd()
+  local docker_config = config.get_docker_options()
 
   local script_args = {
     position.name ~= "tests" and position.path,
@@ -154,26 +156,57 @@ function NeotestAdapter.build_spec(args)
   }
 
   if position.type == "test" then
-    local filter_args = vim.tbl_flatten({
-      "--filter",
-      "::" .. position.name .. "( with data set .*)?$",
-    })
+    local filter_args = vim
+      .iter({
+        "--filter",
+        "::" .. position.name,
+      })
+      :flatten()
+      :totable()
 
     logger.info("position.path:", { position.path })
     logger.info("--filter position.name:", { position.name })
 
-    script_args = vim.tbl_flatten({
-      script_args,
-      filter_args,
-    })
+    script_args = vim
+      .iter({
+        script_args,
+        filter_args,
+      })
+      :flatten()
+      :totable()
   end
 
-  local command = vim.tbl_flatten({
-    program,
-    script_args,
-  })
+  local command = vim
+    .iter({
+      program,
+      script_args,
+    })
+    :flatten()
+    :totable()
 
   logger.trace("PHPUnit command: ", { command })
+
+  local dap_strategy = get_strategy_config(args.strategy, program, script_args)
+
+  if docker_config.enabled then
+    local docker_cmd = docker.build_cmd({
+      env = args.env or config.get_env(),
+      phpunit_cmd = program,
+      script_args = script_args,
+    }, docker_config)
+
+    if docker_cmd then
+      command = docker_cmd
+    end
+
+    if dap_strategy then
+      local docker_dap_config = docker.dap_config(dap_strategy, {
+        phpunit_cmd = program,
+        script_args = script_args,
+      })
+      dap_strategy = docker_dap_config
+    end
+  end
 
   ---@type neotest.RunSpec
   return {
@@ -181,7 +214,7 @@ function NeotestAdapter.build_spec(args)
     context = {
       results_path = results_path,
     },
-    strategy = get_strategy_config(args.strategy, program, script_args),
+    strategy = dap_strategy,
     env = args.env or config.get_env(),
   }
 end
@@ -193,6 +226,10 @@ end
 ---@return neotest.Result[]
 function NeotestAdapter.results(test, result, tree)
   local output_file = test.context.results_path
+
+  if config.get_docker_options().enabled and docker.get_container_id() ~= "" then
+    docker.copy_to_host(output_file)
+  end
 
   local ok, data = pcall(lib.files.read, output_file)
   if not ok then
@@ -255,6 +292,16 @@ setmetatable(NeotestAdapter, {
     elseif type(opts.env) == "table" then
       config.get_env = function()
         return opts.env
+      end
+    end
+    local default_docker_options = vim.deepcopy(config.get_docker_options())
+    if is_callable(opts.docker) then
+      config.get_docker_options = function()
+        return vim.tbl_deep_extend("force", default_docker_options, opts.docker())
+      end
+    elseif type(opts.docker) == "table" then
+      config.get_docker_options = function()
+        return vim.tbl_deep_extend("force", default_docker_options, opts.docker)
       end
     end
     if type(opts.dap) == "table" then

--- a/lua/neotest-phpunit/init.lua
+++ b/lua/neotest-phpunit/init.lua
@@ -149,11 +149,16 @@ function NeotestAdapter.build_spec(args)
   local results_path = async.fn.tempname()
   local program = config.get_phpunit_cmd()
   local docker_config = config.get_docker_options()
+  local coverage_options = config.get_coverage_options()
 
   local script_args = {
     position.name ~= "tests" and position.path,
     "--log-junit=" .. results_path,
   }
+
+  if coverage_options.enabled then
+    table.insert(script_args, coverage_options.args .. " " .. coverage_options.path)
+  end
 
   if position.type == "test" then
     local filter_args = vim
@@ -228,7 +233,7 @@ function NeotestAdapter.results(test, result, tree)
   local output_file = test.context.results_path
 
   if config.get_docker_options().enabled and docker.get_container_id() ~= "" then
-    docker.copy_to_host(output_file)
+    docker.copy_to_host(output_file, config.get_coverage_options())
   end
 
   local ok, data = pcall(lib.files.read, output_file)
@@ -302,6 +307,16 @@ setmetatable(NeotestAdapter, {
     elseif type(opts.docker) == "table" then
       config.get_docker_options = function()
         return vim.tbl_deep_extend("force", default_docker_options, opts.docker)
+      end
+    end
+    local default_coverage_options = vim.deepcopy(config.get_coverage_options())
+    if is_callable(opts.coverage) then
+      config.get_coverage_options = function()
+        return vim.tbl_deep_extend("force", default_coverage_options, opts.coverage())
+      end
+    elseif type(opts.coverage) == "table" then
+      config.get_coverage_options = function()
+        return vim.tbl_deep_extend("force", default_coverage_options, opts.coverage)
       end
     end
     if type(opts.dap) == "table" then

--- a/lua/neotest-phpunit/init.lua
+++ b/lua/neotest-phpunit/init.lua
@@ -164,7 +164,7 @@ function NeotestAdapter.build_spec(args)
     local filter_args = vim
       .iter({
         "--filter",
-        "::" .. position.name,
+        '"::' .. position.name .. '( with data set .*)?$"',
       })
       :flatten()
       :totable()


### PR DESCRIPTION
Running tests inside docker container. Automatically detect via service name or port. Also it patches the DAP configuration to use the docker container as well. So when you are running neotest with dap it attaches to container's xdebug. I'm planning to include an option to pick a container via `vim.ui.select` and attach to it, but it may be kinda out of the scope of this plugin.